### PR TITLE
Added JAXB configure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
       <version>4.0.5</version>
     </dependency>
 
+
+
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>

--- a/src/main/java/com/solvd/delivopt/repo/jaxb/Delivery.java
+++ b/src/main/java/com/solvd/delivopt/repo/jaxb/Delivery.java
@@ -1,0 +1,73 @@
+package com.solvd.delivopt.repo.jaxb;
+
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.util.List;
+
+@XmlRootElement(name = "Delivery")
+public class Delivery {
+
+    private Long id;
+    private String departureTime;
+    private String estimatedArrivalTime;
+    private String type;
+    private List<OrdersDelivery> ordersDeliveries;
+    private List<DeliveryRoute> deliveryRoutes;
+
+    @XmlElement
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @XmlElement
+    public String getDepartureTime() {
+        return departureTime;
+    }
+
+    public void setDepartureTime(String departureTime) {
+        this.departureTime = departureTime;
+    }
+
+    @XmlElement
+    public String getEstimatedArrivalTime() {
+        return estimatedArrivalTime;
+    }
+
+    public void setEstimatedArrivalTime(String estimatedArrivalTime) {
+        this.estimatedArrivalTime = estimatedArrivalTime;
+    }
+
+    @XmlElement
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @XmlElement(name = "OrdersDelivery")
+    public List<OrdersDelivery> getOrdersDeliveries() {
+        return ordersDeliveries;
+    }
+
+    public void setOrdersDeliveries(List<OrdersDelivery> ordersDeliveries) {
+        this.ordersDeliveries = ordersDeliveries;
+    }
+
+    @XmlElement(name = "DeliveryRoute")
+    public List<DeliveryRoute> getDeliveryRoutes() {
+        return deliveryRoutes;
+    }
+
+    public void setDeliveryRoutes(List<DeliveryRoute> deliveryRoutes) {
+        this.deliveryRoutes = deliveryRoutes;
+    }
+}
+

--- a/src/main/java/com/solvd/delivopt/repo/jaxb/DeliveryRoute.java
+++ b/src/main/java/com/solvd/delivopt/repo/jaxb/DeliveryRoute.java
@@ -1,0 +1,38 @@
+package com.solvd.delivopt.repo.jaxb;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "DeliveryRoute")
+public class DeliveryRoute {
+    private Long routeId;
+    private Long deliveryId;
+    private Integer sequence;
+
+    @XmlElement
+    public Long getRouteId() {
+        return routeId;
+    }
+
+    public void setRouteId(Long routeId) {
+        this.routeId = routeId;
+    }
+
+    @XmlElement
+    public Long getDeliveryId() {
+        return deliveryId;
+    }
+
+    public void setDeliveryId(Long deliveryId) {
+        this.deliveryId = deliveryId;
+    }
+
+    @XmlElement
+    public Integer getSequence() {
+        return sequence;
+    }
+
+    public void setSequence(Integer sequence) {
+        this.sequence = sequence;
+    }
+}

--- a/src/main/java/com/solvd/delivopt/repo/jaxb/OrdersDelivery.java
+++ b/src/main/java/com/solvd/delivopt/repo/jaxb/OrdersDelivery.java
@@ -1,0 +1,28 @@
+package com.solvd.delivopt.repo.jaxb;
+
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "OrdersDelivery")
+public class OrdersDelivery {
+    private Long orderId;
+    private Long deliveryId;
+
+    @XmlElement
+    public Long getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(Long orderId) {
+        this.orderId = orderId;
+    }
+
+    @XmlElement
+    public Long getDeliveryId() {
+        return deliveryId;
+    }
+
+    public void setDeliveryId(Long deliveryId) {
+        this.deliveryId = deliveryId;
+    }
+}

--- a/src/main/java/com/solvd/delivopt/repo/jaxb/services/JAXBService.java
+++ b/src/main/java/com/solvd/delivopt/repo/jaxb/services/JAXBService.java
@@ -1,0 +1,49 @@
+package com.solvd.delivopt.repo.jaxb.services;
+
+import com.solvd.delivopt.repo.jaxb.Delivery;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.Unmarshaller;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.List;
+
+public class JAXBService{
+
+    public String marshalDeliveries(List<Delivery> deliveries) throws JAXBException {
+
+        JAXBContext context = JAXBContext.newInstance(Delivery.class);
+        Marshaller marshaller = context.createMarshaller();
+
+
+        marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);
+
+
+        StringWriter writer = new StringWriter();
+
+
+        for (Delivery delivery : deliveries) {
+            marshaller.marshal(delivery, writer);
+        }
+
+        return writer.toString();
+    }
+
+    public List<Delivery> unmarshalDeliveries(String xml) throws JAXBException {
+
+        JAXBContext context = JAXBContext.newInstance(Delivery.class);
+
+
+        Unmarshaller unmarshaller = context.createUnmarshaller();
+
+
+        StringReader reader = new StringReader(xml);
+
+
+        List<Delivery> deliveries = (List<Delivery>) unmarshaller.unmarshal(reader);
+
+        return deliveries;
+    }
+}


### PR DESCRIPTION
Added JAXB support to the project for XML serialization and deserialization. This change enables seamless conversion of Java objects to XML format and vice versa (from XML to Java objects):

1. Created Delivery, OrdersDelivery, and DeliveryRoute classes with JAXB annotations (@XmlRootElement, @XmlElement, etc.) for XML mapping. 

2. Implemented methods for marshaling Java objects to XML and unmarshaling XML back to Java objects.